### PR TITLE
Add LLVM toolchain support to RISC-V build system

### DIFF
--- a/arch/riscv/build.mk
+++ b/arch/riscv/build.mk
@@ -17,27 +17,49 @@ DEFINES := -DF_CPU=$(F_CLK) \
            -DF_TIMER=$(F_TICK) \
            -include config.h
 
-ASFLAGS = -march=rv32imzicsr -mabi=ilp32
-CFLAGS += -Wall -Wextra -Wshadow -Wno-unused-parameter -Werror
+CROSS_COMPILE ?= riscv32-unknown-elf-
+CC_DEFAULT := $(CROSS_COMPILE)gcc
+CC_IS_CLANG := $(shell $(CC_DEFAULT) --version 2>/dev/null | grep -qi clang && echo 1)
+# Architecture flags
+ARCH_FLAGS = -march=rv32imzicsr -mabi=ilp32
+
+# Common compiler flags
+CFLAGS += -Wall -Wextra -Werror -Wshadow -Wno-unused-parameter
 CFLAGS += -O2 -std=gnu99
-CFLAGS += -march=rv32imzicsr -mabi=ilp32
+CFLAGS += $(ARCH_FLAGS)
 CFLAGS += -mstrict-align -ffreestanding -nostdlib -fomit-frame-pointer
 CFLAGS += $(INC_DIRS) $(DEFINES) -fdata-sections -ffunction-sections
+
+ifeq ($(CC_IS_CLANG),1)
+    CC    = $(CROSS_COMPILE)clang
+    AS    = $(CROSS_COMPILE)clang
+    LD    = $(CROSS_COMPILE)ld.lld
+    DUMP  = $(CROSS_COMPILE)llvm-objdump -M no-aliases
+    READ  = $(CROSS_COMPILE)llvm-readelf
+    OBJ   = $(CROSS_COMPILE)llvm-objcopy
+    SIZE  = $(CROSS_COMPILE)llvm-size
+
+    CFLAGS += --target=riscv32-unknown-elf
+    CFLAGS += -Wno-unused-command-line-argument
+    ASFLAGS = --target=riscv32-unknown-elf $(ARCH_FLAGS)
+    LDFLAGS = -m elf32lriscv --gc-sections
+else
+    CC    = $(CC_DEFAULT)
+    AS    = $(CROSS_COMPILE)as
+    LD    = $(CROSS_COMPILE)ld
+    DUMP  = $(CROSS_COMPILE)objdump -Mno-aliases
+    READ  = $(CROSS_COMPILE)readelf
+    OBJ   = $(CROSS_COMPILE)objcopy
+    SIZE  = $(CROSS_COMPILE)size
+
+    ASFLAGS = $(ARCH_FLAGS)
+    LDFLAGS = -melf32lriscv --gc-sections
+endif
+
+AR    = $(CROSS_COMPILE)ar
+
 ARFLAGS = r
-
-# Linker flags
-LDFLAGS = -melf32lriscv --gc-sections
 LDSCRIPT = $(ARCH_DIR)/riscv32-qemu.ld
-
-CROSS_COMPILE ?= riscv-none-elf-
-CC = $(CROSS_COMPILE)gcc
-AS = $(CROSS_COMPILE)as
-LD = $(CROSS_COMPILE)ld
-DUMP = $(CROSS_COMPILE)objdump -Mno-aliases
-READ = $(CROSS_COMPILE)readelf
-OBJ = $(CROSS_COMPILE)objcopy
-SIZE = $(CROSS_COMPILE)size
-AR = $(CROSS_COMPILE)ar
 
 HAL_OBJS := boot.o hal.o muldiv.o
 HAL_OBJS := $(addprefix $(BUILD_KERNEL_DIR)/,$(HAL_OBJS))

--- a/kernel/pipe.c
+++ b/kernel/pipe.c
@@ -34,7 +34,7 @@ static inline uint16_t pipe_free_space_internal(const pipe_t *p)
     return (p->mask + 1) - p->used;
 }
 
-static inline char pipe_get_byte(pipe_t *p)
+static inline __attribute__((__unused__)) char pipe_get_byte(pipe_t *p)
 {
     char val = p->buf[p->head];
     p->head = (p->head + 1) & p->mask;
@@ -42,7 +42,7 @@ static inline char pipe_get_byte(pipe_t *p)
     return val;
 }
 
-static inline void pipe_put_byte(pipe_t *p, char c)
+static inline __attribute__((__unused__)) void pipe_put_byte(pipe_t *p, char c)
 {
     p->buf[p->tail] = c;
     p->tail = (p->tail + 1) & p->mask;

--- a/lib/malloc.c
+++ b/lib/malloc.c
@@ -109,7 +109,6 @@ void free(void *ptr)
 static void selective_coalesce(void)
 {
     memblock_t *p = first_free;
-    uint32_t coalesced = 0;
 
     while (p && p->next) {
         /* Merge only when blocks are FREE *and* adjacent in memory */
@@ -117,7 +116,6 @@ static void selective_coalesce(void)
         if (!IS_USED(p) && !IS_USED(p->next) && pend == (uint8_t *) p->next) {
             p->size = GET_SIZE(p) + sizeof(memblock_t) + GET_SIZE(p->next);
             p->next = p->next->next;
-            coalesced++;
             free_blocks_count--;
         } else {
             p = p->next;


### PR DESCRIPTION
This commit introduces initial support for compiling the RISC-V target using the LLVM toolchain.